### PR TITLE
cuda-cuxxfilt 12.9.82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ source:
   sha256: ec5911d680394d90968c480c7359e7f5a4025b9c4806dad673d489e57585afd3  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -61,6 +61,7 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: cu++filt decodes low-level identifiers that have been mangled by CUDA C++
   description: |
     cu++filt decodes (demangles) low-level identifiers that have been mangled by
@@ -68,6 +69,7 @@ about:
     output of cu++filt is either the demangled name if the name decodes to a CUDA
     C++ name, or the original name itself.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-cuxxfilt 12.9.82

**Destination channel:** defaults

### Links

- [PKG-12772](https://anaconda.atlassian.net/browse/PKG-12772) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds

[PKG-12772]: https://anaconda.atlassian.net/browse/PKG-12772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ